### PR TITLE
Handle 'labelled' vectors as categorical variables

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -88,9 +88,9 @@ find_class <- function(df, type = c("numerical", "categorical", "categorical2"),
   if (type == "numerical") {
     idx <- which(clist %in% c("integer", "numeric"))
   } else if (type == "categorical") {
-    idx <- which(clist %in% c("factor", "ordered"))
+    idx <- which(clist %in% c("factor", "ordered", "labelled"))
   } else if (type == "categorical2") {
-    idx <- which(clist %in% c("factor", "ordered", "character"))
+    idx <- which(clist %in% c("factor", "ordered", "labelled", "character"))
   }
 
   if (!index) idx <- names(df)[idx]


### PR DESCRIPTION
Using [haven](http://haven.tidyverse.org/) package from tidyverse, one can get categorical variables with the 'labelled' class. 

The following code illustrates the issue, using the SPSS dataset [DatabaseTest.sav](https://github.com/obiba/obiba-home/raw/master/opal/seed/fs/home/administrator/spss/DatabaseTest.sav):

```
library(haven)
df <- read_spss("DatabaseTest.sav")
library(dlookr)
diagnose_category(df)
```
The changes make dlookr diagnose 'labelled' vectors appropriately.