### PR TITLE
Fix typos in html diagnosis report

### DIFF
--- a/R/html_diagnose.R
+++ b/R/html_diagnose.R
@@ -60,7 +60,7 @@ html_toprank <- function(.data, variable = NULL, drop_variable = FALSE) {
     summarise(top_freq = sum(freq), .groups = "drop") %>% 
     mutate(other_freq = N - top_freq) %>% 
     filter(other_freq > 0) %>% 
-    mutate(levels = "Other levles",
+    mutate(levels = "Other levels",
            N = N,
            freq = other_freq,
            ratio = freq / N,
@@ -85,7 +85,7 @@ html_toprank <- function(.data, variable = NULL, drop_variable = FALSE) {
   # Render a bar chart in the background of the cell
   bar_style <- function(width = 1, fill = "#e6e6e666", levels = NULL) {
     fill <- ifelse(levels %in% "Missing", "#cdcdcd99", fill)
-    fill <- ifelse(levels %in% "Other levles", "#0072bc66", fill)
+    fill <- ifelse(levels %in% "Other levels", "#0072bc66", fill)
     
     position <- paste0(width * 100, "%")
     image <- sprintf("linear-gradient(90deg, %1$s %2$s, transparent %2$s)", 
@@ -152,7 +152,7 @@ html_paged_toprank <- function(.data, top = 10, type = "n", variable = NULL,
     summarise(top_freq = sum(freq), .groups = "drop") %>% 
     mutate(other_freq = N - top_freq) %>% 
     filter(other_freq > 0) %>% 
-    mutate(levels = "Other levles",
+    mutate(levels = "Other levels",
            N = N,
            freq = other_freq,
            ratio = freq / N,
@@ -540,7 +540,7 @@ html_missing <- function(tab, grade = c("Good" = 0.05, "OK" = 0.1,
       diagn_missing,
       defaultColDef = colDef(style = "font-size: 14px;color: hsl(0, 0%, 40%);"),
       columns = list(
-        variables = colDef(name = "Variables"),  
+        variables = colDef(name = "Variable"),  
         missing_count = colDef(name = "Missing",
                                width = 120,
                                format = colFormat(separators = TRUE)),    
@@ -560,7 +560,7 @@ html_missing <- function(tab, grade = c("Good" = 0.05, "OK" = 0.1,
                           tagList(badge, value)
                         }),
         recommend = colDef(
-          name = "Recommend"
+          name = "Recommendation"
         )
       )
     )
@@ -730,7 +730,7 @@ html_outlier <- function(.data, theme = c("orange", "blue")[1],
         height = 400, device = grDevices::png)
         
         shiny::tabsetPanel(
-          shiny::tabPanel("Distirubution", p_outlier,
+          shiny::tabPanel("Distribution", p_outlier,
                           hr(style = "border-top: 1px solid black;"),
                           style = "padding-top:5px; padding-bottom:25px;"),          
           shiny::tabPanel("Statistics", outlier_df,

--- a/R/report.R
+++ b/R/report.R
@@ -45,7 +45,7 @@ eda_paged_report <- function(.data, ...) {
 #'     \itemize{
 #'       \item Data Structures
 #'       \item Data Types
-#'       \item Job Informations
+#'       \item Job Information
 #'     }
 #'     \item Warnings
 #'     \item Variables
@@ -276,7 +276,7 @@ diagnose_web_report.data.frame <- function(.data, output_file = NULL, output_dir
 #'   \item Overview
 #'   \itemize{
 #'     \item Data Structures 
-#'     \item Job Informations
+#'     \item Job Information
 #'     \item Warnings
 #'     \item Variables
 #'   } 
@@ -602,7 +602,7 @@ diagnose_paged_report.data.frame <- function(.data, output_format = c("pdf", "ht
 #'   \itemize{
 #'     \item Data Structures 
 #'     \item Data Types
-#'     \item Job Informations
+#'     \item Job Information
 #'   }
 #'   \item Univariate Analysis
 #'   \itemize{
@@ -847,7 +847,7 @@ eda_web_report.data.frame <- function(.data, target = NULL, output_file = NULL,
 #'   \item Overview
 #'   \itemize{
 #'     \item Data Structures 
-#'     \item Job Informations
+#'     \item Job Information
 #'   } 
 #'   \item Univariate Analysis
 #'   \itemize{
@@ -1141,7 +1141,7 @@ eda_paged_report.data.frame <- function(.data, target = NULL, output_format = c(
 #'   \itemize{
 #'     \item Data Structures 
 #'     \item Data Types
-#'     \item Job Informations
+#'     \item Job Information
 #'   }
 #'   \item Imputation
 #'   \itemize{
@@ -1353,7 +1353,7 @@ transformation_web_report <- function(.data, target = NULL, output_file = NULL,
 #'   \item Overview
 #'   \itemize{
 #'     \item Data Structures 
-#'     \item Job Informations
+#'     \item Job Information
 #'   } 
 #'   \item Imputation
 #'   \itemize{

--- a/R/report_tbl_dbi.R
+++ b/R/report_tbl_dbi.R
@@ -17,7 +17,7 @@
 #'     \itemize{
 #'       \item Data Structures
 #'       \item Data Types
-#'       \item Job Informations
+#'       \item Job Information
 #'     }
 #'     \item Warnings
 #'     \item Variables
@@ -161,7 +161,7 @@ diagnose_web_report.tbl_dbi <- function(.data, output_file = NULL, output_dir = 
 #'   \item Overview
 #'   \itemize{
 #'     \item Data Structures 
-#'     \item Job Informations
+#'     \item Job Information
 #'     \item Warnings
 #'     \item Variables
 #'   } 
@@ -340,7 +340,7 @@ diagnose_paged_report.tbl_dbi <- function(.data, output_format = c("pdf", "html"
 #'   \itemize{
 #'     \item Data Structures 
 #'     \item Data Types
-#'     \item Job Informations
+#'     \item Job Information
 #'   }
 #'   \item Univariate Analysis
 #'   \itemize{
@@ -477,7 +477,7 @@ eda_web_report.tbl_dbi <- function(.data, target = NULL, output_file = NULL,
 #'   \item Overview
 #'   \itemize{
 #'     \item Data Structures 
-#'     \item Job Informations
+#'     \item Job Information
 #'   } 
 #'   \item Univariate Analysis
 #'   \itemize{

--- a/README.Rmd
+++ b/README.Rmd
@@ -903,7 +903,7 @@ The contents of the report are as follows.:
     + Data Structures
         + Data Structures
         + Data Types
-        + Job Informations
+        + Job Information
     + Warnings
     + Variables
 * Missing Values
@@ -978,7 +978,7 @@ The contents of the report are as follows.:
 
 * Overview
     + Data Structures
-    + Job Informations
+    + Job Information
     + Warnings
     + Variables
 * Missing Values
@@ -1078,7 +1078,7 @@ The contents of the report are as follows.:
 * Overview
     + Data Structures
     + Data Types
-    + Job Informations
+    + Job Information
 * Univariate Analysis
     + Descriptive Statistics
     + Normality Test
@@ -1145,7 +1145,7 @@ The contents of the report are as follows.:
 
 * Overview
     + Data Structures
-    + Job Informations
+    + Job Information
 * Univariate Analysis
     + Descriptive Statistics
         + Numerical Variables
@@ -1236,7 +1236,7 @@ The contents of the report are as follows.:
 * Overview
     + Data Structures
     + Data Types
-    + Job Informations
+    + Job Information
 * Imputation
     + Missing Values
     + Outliers
@@ -1296,7 +1296,7 @@ The contents of the report are as follows.:
 
 * Overview
     + Data Structures
-    + Job Informations
+    + Job Information
 * Imputation
     + Missing Values
     + Outliers

--- a/README.md
+++ b/README.md
@@ -2067,7 +2067,7 @@ The contents of the report are as follows.:
   - Data Structures
     - Data Structures
     - Data Types
-    - Job Informations
+    - Job Information
   - Warnings
   - Variables
 - Missing Values
@@ -2156,7 +2156,7 @@ The contents of the report are as follows.:
 
 - Overview
   - Data Structures
-  - Job Informations
+  - Job Information
   - Warnings
   - Variables
 - Missing Values
@@ -2273,7 +2273,7 @@ The contents of the report are as follows.:
 - Overview
   - Data Structures
   - Data Types
-  - Job Informations
+  - Job Information
 - Univariate Analysis
   - Descriptive Statistics
   - Normality Test
@@ -2349,7 +2349,7 @@ The contents of the report are as follows.:
 
 - Overview
   - Data Structures
-  - Job Informations
+  - Job Information
 - Univariate Analysis
   - Descriptive Statistics
     - Numerical Variables
@@ -2457,7 +2457,7 @@ The contents of the report are as follows.:
 - Overview
   - Data Structures
   - Data Types
-  - Job Informations
+  - Job Information
 - Imputation
   - Missing Values
   - Outliers
@@ -2527,7 +2527,7 @@ The contents of the report are as follows.:
 
 - Overview
   - Data Structures
-  - Job Informations
+  - Job Information
 - Imputation
   - Missing Values
   - Outliers

--- a/docs/index.html
+++ b/docs/index.html
@@ -1938,7 +1938,7 @@
 <ul>
 <li>Data Structures</li>
 <li>Data Types</li>
-<li>Job Informations</li>
+<li>Job Information</li>
 </ul>
 </li>
 <li>Warnings</li>
@@ -2074,7 +2074,7 @@ The dynamic contents of the report
 <li>Overview
 <ul>
 <li>Data Structures</li>
-<li>Job Informations</li>
+<li>Job Information</li>
 <li>Warnings</li>
 <li>Variables</li>
 </ul>
@@ -2266,7 +2266,7 @@ The dynamic contents of the report
 <ul>
 <li>Data Structures</li>
 <li>Data Types</li>
-<li>Job Informations</li>
+<li>Job Information</li>
 </ul>
 </li>
 <li>Univariate Analysis
@@ -2393,7 +2393,7 @@ The part of the report
 <li>Overview
 <ul>
 <li>Data Structures</li>
-<li>Job Informations</li>
+<li>Job Information</li>
 </ul>
 </li>
 <li>Univariate Analysis
@@ -2564,7 +2564,7 @@ The dynamic contents of the report
 <ul>
 <li>Data Structures</li>
 <li>Data Types</li>
-<li>Job Informations</li>
+<li>Job Information</li>
 </ul>
 </li>
 <li>Imputation
@@ -2672,7 +2672,7 @@ The part of the report
 <li>Overview
 <ul>
 <li>Data Structures</li>
-<li>Job Informations</li>
+<li>Job Information</li>
 </ul>
 </li>
 <li>Imputation

--- a/docs/reference/diagnose_paged_report.data.frame.html
+++ b/docs/reference/diagnose_paged_report.data.frame.html
@@ -238,7 +238,7 @@ If not installed, you must use output_format = "html".</p>
 
 <p>Reported from the data diagnosis is as follows.</p>
 <ul><li><p>Overview</p><ul><li><p>Data Structures</p></li>
-<li><p>Job Informations</p></li>
+<li><p>Job Information</p></li>
 <li><p>Warnings</p></li>
 <li><p>Variables</p></li>
 </ul></li>

--- a/docs/reference/diagnose_paged_report.tbl_dbi.html
+++ b/docs/reference/diagnose_paged_report.tbl_dbi.html
@@ -239,7 +239,7 @@ If not installed, you must use output_format = "html".</p>
 
 <p>Reported from the data diagnosis is as follows.</p>
 <ul><li><p>Overview</p><ul><li><p>Data Structures</p></li>
-<li><p>Job Informations</p></li>
+<li><p>Job Information</p></li>
 <li><p>Warnings</p></li>
 <li><p>Variables</p></li>
 </ul></li>

--- a/docs/reference/diagnose_web_report.data.frame.html
+++ b/docs/reference/diagnose_web_report.data.frame.html
@@ -188,7 +188,7 @@ than data with a small number of variables.</p>
 <p>Reported from the data diagnosis is as follows.</p>
 <ul><li><p>Overview</p><ul><li><p>Data Structures</p><ul><li><p>Data Structures</p></li>
 <li><p>Data Types</p></li>
-<li><p>Job Informations</p></li>
+<li><p>Job Information</p></li>
 </ul></li>
 <li><p>Warnings</p></li>
 <li><p>Variables</p></li>

--- a/docs/reference/diagnose_web_report.tbl_dbi.html
+++ b/docs/reference/diagnose_web_report.tbl_dbi.html
@@ -189,7 +189,7 @@ than data with a small number of variables.</p>
 <p>Reported from the data diagnosis is as follows.</p>
 <ul><li><p>Overview</p><ul><li><p>Data Structures</p><ul><li><p>Data Structures</p></li>
 <li><p>Data Types</p></li>
-<li><p>Job Informations</p></li>
+<li><p>Job Information</p></li>
 </ul></li>
 <li><p>Warnings</p></li>
 <li><p>Variables</p></li>

--- a/docs/reference/eda_paged_report.data.frame.html
+++ b/docs/reference/eda_paged_report.data.frame.html
@@ -211,7 +211,7 @@ If not installed, you must use output_format = "html".</p>
 
 <p>The EDA process will report the following information:</p>
 <ul><li><p>Overview</p><ul><li><p>Data Structures</p></li>
-<li><p>Job Informations</p></li>
+<li><p>Job Information</p></li>
 </ul></li>
 <li><p>Univariate Analysis</p><ul><li><p>Descriptive Statistics</p><ul><li><p>Numerical Variables</p></li>
 <li><p>Categorical Variables</p></li>

--- a/docs/reference/eda_paged_report.tbl_dbi.html
+++ b/docs/reference/eda_paged_report.tbl_dbi.html
@@ -212,7 +212,7 @@ If not installed, you must use output_format = "html".</p>
 
 <p>The EDA process will report the following information:</p>
 <ul><li><p>Overview</p><ul><li><p>Data Structures</p></li>
-<li><p>Job Informations</p></li>
+<li><p>Job Information</p></li>
 </ul></li>
 <li><p>Univariate Analysis</p><ul><li><p>Descriptive Statistics</p><ul><li><p>Numerical Variables</p></li>
 <li><p>Categorical Variables</p></li>

--- a/docs/reference/eda_web_report.data.frame.html
+++ b/docs/reference/eda_web_report.data.frame.html
@@ -180,7 +180,7 @@ This feature is useful for EDA of data with many variables, rather than data wit
 <p>Reported from the EDA is as follows.</p>
 <ul><li><p>Overview</p><ul><li><p>Data Structures</p></li>
 <li><p>Data Types</p></li>
-<li><p>Job Informations</p></li>
+<li><p>Job Information</p></li>
 </ul></li>
 <li><p>Univariate Analysis</p><ul><li><p>Descriptive Statistics</p></li>
 <li><p>Normality Test</p></li>

--- a/docs/reference/eda_web_report.tbl_dbi.html
+++ b/docs/reference/eda_web_report.tbl_dbi.html
@@ -181,7 +181,7 @@ This feature is useful for EDA of data with many variables, rather than data wit
 <p>Reported from the EDA is as follows.</p>
 <ul><li><p>Overview</p><ul><li><p>Data Structures</p></li>
 <li><p>Data Types</p></li>
-<li><p>Job Informations</p></li>
+<li><p>Job Information</p></li>
 </ul></li>
 <li><p>Univariate Analysis</p><ul><li><p>Descriptive Statistics</p></li>
 <li><p>Normality Test</p></li>

--- a/docs/reference/transformation_paged_report.html
+++ b/docs/reference/transformation_paged_report.html
@@ -203,7 +203,7 @@ If not installed, you must use output_format = "html".</p>
 
 <p>TThe transformation process will report the following information:</p>
 <ul><li><p>Overview</p><ul><li><p>Data Structures</p></li>
-<li><p>Job Informations</p></li>
+<li><p>Job Information</p></li>
 </ul></li>
 <li><p>Imputation</p><ul><li><p>Missing Values</p></li>
 <li><p>Outliers</p></li>

--- a/docs/reference/transformation_web_report.html
+++ b/docs/reference/transformation_web_report.html
@@ -173,7 +173,7 @@ than data with a small number of variables.</p>
 <p>The transformation process will report the following information:</p>
 <ul><li><p>Overview</p><ul><li><p>Data Structures</p></li>
 <li><p>Data Types</p></li>
-<li><p>Job Informations</p></li>
+<li><p>Job Information</p></li>
 </ul></li>
 <li><p>Imputation</p><ul><li><p>Missing Values</p></li>
 <li><p>Outliers</p></li>

--- a/inst/report/diagnosis_paged_temp.Rmd
+++ b/inst/report/diagnosis_paged_temp.Rmd
@@ -383,7 +383,7 @@ knitr::kables(format = "html",
   cat()
 ```
 
-## Job Informations
+## Job Information
 
 ```{r overview-job, results='asis'}
 division <- c("dataset" ,"dataset", "job", "job", "job")

--- a/inst/report/diagnosis_temp.Rmd
+++ b/inst/report/diagnosis_temp.Rmd
@@ -424,7 +424,7 @@ knitr::kable(tab_right, digits = 2, caption = cap, format = "html",
              table.attr = "style=\"color: hsl(0, 0%, 40%);margin-right:30px !important;\"") %>% 
   kable_styling(full_width = FALSE, font_size = 14, position = "float_left") 
 
-cap <- "Job Informations"
+cap <- "Job Information"
 knitr::kable(overview, caption = cap, format = "html",
              table.attr = "style=\"color: hsl(0, 0%, 40%);\"") %>% 
   kable_styling(full_width = FALSE, font_size = 14, position = "left") 
@@ -515,7 +515,7 @@ tab_warning %>%
       ),
       status = colDef(name = "Types", width = 100),
       recommend = colDef(
-        name = "Recommends", 
+        name = "Recommendations", 
         width = 130,
         cell = function(value) {
           class <- paste0("tag recommend-", tolower(value))

--- a/inst/report/eda_paged_temp.Rmd
+++ b/inst/report/eda_paged_temp.Rmd
@@ -113,7 +113,7 @@ knitr::kables(format = "html",
   cat()
 ```
 
-## Job Informations
+## Job Information
 
 ```{r overview-job, results='asis'}
 division <- c("dataset" ,"dataset" ,"dataset", "job", "job", "job")

--- a/inst/report/eda_temp.Rmd
+++ b/inst/report/eda_temp.Rmd
@@ -238,7 +238,7 @@ knitr::kable(tab_right, digits = 2, caption = cap, format = "html",
              table.attr = "style=\"color: hsl(0, 0%, 40%);margin-right:30px !important;\"") %>% 
   kable_styling(full_width = FALSE, font_size = 14, position = "float_left") 
 
-cap <- "Job Informations"
+cap <- "Job Information"
 knitr::kable(overview, caption = cap, format = "html",
              table.attr = "style=\"color: hsl(0, 0%, 40%);\"") %>% 
   kable_styling(full_width = FALSE, font_size = 14, position = "left") 

--- a/inst/report/transformation_paged_temp.Rmd
+++ b/inst/report/transformation_paged_temp.Rmd
@@ -112,7 +112,7 @@ knitr::kables(format = "html",
   cat()
 ```
 
-## Job Informations
+## Job Information
 
 ```{r overview-job, results='asis'}
 division <- c("dataset" ,"dataset" ,"dataset", "job", "job", "job")

--- a/inst/report/transformation_temp.Rmd
+++ b/inst/report/transformation_temp.Rmd
@@ -221,7 +221,7 @@ knitr::kable(tab_right, digits = 2, caption = cap, format = "html",
              table.attr = "style=\"color: hsl(0, 0%, 40%);margin-right:30px !important;\"") %>% 
   kable_styling(full_width = FALSE, font_size = 14, position = "float_left") 
 
-cap <- "Job Informations"
+cap <- "Job Information"
 knitr::kable(overview, caption = cap, format = "html",
              table.attr = "style=\"color: hsl(0, 0%, 40%);\"") %>% 
   kable_styling(full_width = FALSE, font_size = 14, position = "left") 

--- a/man/diagnose_paged_report.data.frame.Rd
+++ b/man/diagnose_paged_report.data.frame.Rd
@@ -125,7 +125,7 @@ Reported from the data diagnosis is as follows.
   \item Overview
   \itemize{
     \item Data Structures 
-    \item Job Informations
+    \item Job Information
     \item Warnings
     \item Variables
   } 

--- a/man/diagnose_paged_report.tbl_dbi.Rd
+++ b/man/diagnose_paged_report.tbl_dbi.Rd
@@ -127,7 +127,7 @@ Reported from the data diagnosis is as follows.
   \item Overview
   \itemize{
     \item Data Structures 
-    \item Job Informations
+    \item Job Information
     \item Warnings
     \item Variables
   } 

--- a/man/diagnose_web_report.data.frame.Rd
+++ b/man/diagnose_web_report.data.frame.Rd
@@ -92,7 +92,7 @@ Reported from the data diagnosis is as follows.
     \itemize{
       \item Data Structures
       \item Data Types
-      \item Job Informations
+      \item Job Information
     }
     \item Warnings
     \item Variables

--- a/man/diagnose_web_report.tbl_dbi.Rd
+++ b/man/diagnose_web_report.tbl_dbi.Rd
@@ -94,7 +94,7 @@ Reported from the data diagnosis is as follows.
     \itemize{
       \item Data Structures
       \item Data Types
-      \item Job Informations
+      \item Job Information
     }
     \item Warnings
     \item Variables

--- a/man/eda_paged_report.data.frame.Rd
+++ b/man/eda_paged_report.data.frame.Rd
@@ -107,7 +107,7 @@ The EDA process will report the following information:
   \item Overview
   \itemize{
     \item Data Structures 
-    \item Job Informations
+    \item Job Information
   } 
   \item Univariate Analysis
   \itemize{

--- a/man/eda_paged_report.tbl_dbi.Rd
+++ b/man/eda_paged_report.tbl_dbi.Rd
@@ -109,7 +109,7 @@ The EDA process will report the following information:
   \item Overview
   \itemize{
     \item Data Structures 
-    \item Job Informations
+    \item Job Information
   } 
   \item Univariate Analysis
   \itemize{

--- a/man/eda_web_report.data.frame.Rd
+++ b/man/eda_web_report.data.frame.Rd
@@ -84,7 +84,7 @@ Reported from the EDA is as follows.
   \itemize{
     \item Data Structures 
     \item Data Types
-    \item Job Informations
+    \item Job Information
   }
   \item Univariate Analysis
   \itemize{

--- a/man/eda_web_report.tbl_dbi.Rd
+++ b/man/eda_web_report.tbl_dbi.Rd
@@ -86,7 +86,7 @@ Reported from the EDA is as follows.
   \itemize{
     \item Data Structures 
     \item Data Types
-    \item Job Informations
+    \item Job Information
   }
   \item Univariate Analysis
   \itemize{

--- a/man/transformation_paged_report.Rd
+++ b/man/transformation_paged_report.Rd
@@ -101,7 +101,7 @@ TThe transformation process will report the following information:
   \item Overview
   \itemize{
     \item Data Structures 
-    \item Job Informations
+    \item Job Information
   } 
   \item Imputation
   \itemize{

--- a/man/transformation_web_report.Rd
+++ b/man/transformation_web_report.Rd
@@ -79,7 +79,7 @@ The transformation process will report the following information:
   \itemize{
     \item Data Structures 
     \item Data Types
-    \item Job Informations
+    \item Job Information
   }
   \item Imputation
   \itemize{

--- a/vignettes/EDA.Rmd
+++ b/vignettes/EDA.Rmd
@@ -457,7 +457,7 @@ The contents of the report are as follows.:
 * Overview
     + Data Structures
     + Data Types
-    + Job Informations
+    + Job Information
 * Univariate Analysis
     + Descriptive Statistics
     + Normality Test
@@ -524,7 +524,7 @@ The contents of the report are as follows.:
 
 * Overview
     + Data Structures
-    + Job Informations
+    + Job Information
 * Univariate Analysis
     + Descriptive Statistics
         + Numerical Variables

--- a/vignettes/diagonosis.Rmd
+++ b/vignettes/diagonosis.Rmd
@@ -340,7 +340,7 @@ The contents of the report are as follows.:
     + Data Structures
         + Data Structures
         + Data Types
-        + Job Informations
+        + Job Information
     + Warnings
     + Variables
 * Missing Values
@@ -425,7 +425,7 @@ The contents of the report are as follows.:
 
 * Overview
     + Data Structures
-    + Job Informations
+    + Job Information
     + Warnings
     + Variables
 * Missing Values

--- a/vignettes/transformation.Rmd
+++ b/vignettes/transformation.Rmd
@@ -390,7 +390,7 @@ The contents of the report are as follows.:
 * Overview
     + Data Structures
     + Data Types
-    + Job Informations
+    + Job Information
 * Imputation
     + Missing Values
     + Outliers
@@ -450,7 +450,7 @@ The contents of the report are as follows.:
 
 * Overview
     + Data Structures
-    + Job Informations
+    + Job Information
 * Imputation
     + Missing Values
     + Outliers


### PR DESCRIPTION
Fixes #119. 

Correcting typos found in html diagnosis report, and if also detected in other files.

- Job Informations > Job Information.
- Other levles > Other levels.
- Recommend > Recommendation.
- Distirubution > Distribution.

Files in dlookr/docs/articles/ were not updated.